### PR TITLE
fix: correct Preisliste image aspect ratio from 0.75 to 0.93

### DIFF
--- a/components/Price.js
+++ b/components/Price.js
@@ -40,8 +40,8 @@ export default function Price() {
 
         <Image
           src={'/preisliste.webp'}
-          width={600}
-          height={800}
+          width={640}
+          height={685}
           alt={'Preisliste'}
           className={styles.list}
           priority


### PR DESCRIPTION
Updated image dimensions from 600x800 to 640x685 to match the actual image file dimensions, resolving PageSpeed Insights aspect ratio warning.