### PR TITLE
Fix image aspect ratio mismatch on website

### DIFF
--- a/components/Price.js
+++ b/components/Price.js
@@ -40,8 +40,8 @@ export default function Price() {
 
         <Image
           src={'/preisliste.webp'}
-          width={640}
-          height={685}
+          width={1906}
+          height={2040}
           alt={'Preisliste'}
           className={styles.list}
           priority

--- a/styles/components/Price.module.css
+++ b/styles/components/Price.module.css
@@ -114,7 +114,7 @@
   display: block;
   border-radius: 8px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-  aspect-ratio: 3 / 4;
+  aspect-ratio: 1906 / 2040;
 }
 
 /* Desktop and tablet constraints */


### PR DESCRIPTION
Update image dimensions from 640x685 to 1906x2040 to match the actual dimensions of the preisliste.webp file. This fixes the aspect ratio mismatch reported by Lighthouse.