### PR TITLE
Fix header item spacing on home page

### DIFF
--- a/styles/components/Header.module.css
+++ b/styles/components/Header.module.css
@@ -45,7 +45,7 @@
 }
 
 .h1 {
-    font-size: 1.3rem;
+    font-size: 1.6rem;
 }
 
 .h2 {
@@ -67,6 +67,7 @@
 
 .subHeading p {
     color: white;
+    font-size: 1.1rem;
     line-height: 2rem;
     text-align: center;
 }
@@ -185,7 +186,7 @@
     }
 
     .h1 {
-        font-size: 1rem;
+        font-size: 1.25rem;
     }
 
     .h1,
@@ -220,7 +221,7 @@
 
 @media (max-width: 375px) {
     .h1 {
-        font-size: .8rem;
+        font-size: 1rem;
     }
 
     .h2 {
@@ -228,7 +229,7 @@
     }
 
     .subHeading {
-        font-size: .9rem;
+        font-size: 1rem;
     }
 }
 
@@ -242,7 +243,7 @@
     }
 
     .h1 {
-        font-size: .72rem;
+        font-size: .9rem;
         margin-bottom: .5rem;
     }
 


### PR DESCRIPTION
- Increase main title (h1) from 1.3rem to 1.6rem
- Add explicit font-size of 1.1rem to subheading text
- Proportionally adjust responsive breakpoints:
  - 425px: h1 1rem → 1.25rem
  - 375px: h1 0.8rem → 1rem, subheading 0.9rem → 1rem
  - 320px: h1 0.72rem → 0.9rem