### PR TITLE
fix(agentic): semantic list markup for services grid and add llms.txt

### DIFF
--- a/components/Services.js
+++ b/components/Services.js
@@ -169,9 +169,9 @@ export default function Services() {
                     </p>
                 </div>
             </header>
-            <div className={ styles.grid } role="list" aria-label="Physiotherapie Leistungen">
+            <ul className={ styles.grid } role="list" aria-label="Physiotherapie Leistungen">
                 { SERVICES.map((s) => (
-                    <article className={ styles.card } key={ s.code } role="listitem">
+                    <li className={ styles.card } key={ s.code }>
                         <div className={ styles.cardHead }>
                             <span className={ styles.icon }>{ s.icon }</span>
                             <span className={ styles.tag }>{ s.roman }</span>
@@ -182,9 +182,9 @@ export default function Services() {
                             <span>{ s.code }</span>
                             <span className={ styles.price }>{ s.time || '60 min' }</span>
                         </div>
-                    </article>
+                    </li>
                 )) }
-            </div>
+            </ul>
             <p className={ styles.note }>
                 <em>*</em> 30-minütige Behandlungen werden als volle Stunde abgerechnet.
             </p>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,29 @@
+# Saim Mobilephysio
+
+> Mobile Physiotherapie in Sankt Augustin, Bonn und Umgebung: Hausbesuche, Manuelltherapie, Lymphdrainage und Personal Training mit Faranak Nokhbehzaeem.
+
+Saim Mobilephysio ist eine mobile Physiotherapie-Praxis. Alle Behandlungen finden als Hausbesuche statt — Liege, Materialien und Tapes werden mitgebracht. Eine Sitzung dauert verlässlich 60 Minuten. Behandlungen sind mit ärztlichem Rezept oder ohne Verordnung (präventiv, Personal Training, Wellness) möglich; abgerechnet wird nach den Sätzen des Honorarkatalogs.
+
+- Inhaberin und Therapeutin: Faranak Nokhbehzaeem, staatlich anerkannte Physiotherapeutin, Manuelltherapeutin, Ödemtherapeutin und Personal Trainerin
+- Adresse: Wacholderweg 6, 53757 Sankt Augustin, Nordrhein-Westfalen, Deutschland
+- Telefon: +49 157 85 90 8915
+- E-Mail: info@saim-mobilephysio.de
+- Sprachen: Deutsch, Persisch (Farsi)
+- Einzugsgebiet: Radius von 20 km um Sankt Augustin — u. a. Bonn, Siegburg, Troisdorf, Hennef, Königswinter, Bad Honnef, Niederkassel, Lohmar, Much
+- Preisspanne: 15 EUR bis 150 EUR, Hausbesuch 28 EUR
+
+## Leistungen
+
+Zwölf Behandlungsformen: Manuelle Therapie, Physiotherapie (Krankengymnastik), Manuelle Lymphdrainage, Atemtherapie, Migränetherapie, Akupressur, Beckenboden- und Rückentraining, Koordinations-, Ausdauer- und Krafttraining (Personal Training), Wellnessbehandlungen, Kinesiologische Tapetechniken, Massage sowie Ozon-/Plasma-Therapie.
+
+## Wichtige Seiten
+
+- [Startseite](https://saim-mobilephysio.de/): Überblick über Praxis und Angebot
+- [Leistungen](https://saim-mobilephysio.de/#leistungen): Alle Behandlungsformen im Detail
+- [Preise](https://saim-mobilephysio.de/#preise): Preisliste nach Honorarkatalog
+- [Einzugsgebiet](https://saim-mobilephysio.de/#einzugsgebiet): Orte und Radius der Hausbesuche
+- [Häufige Fragen](https://saim-mobilephysio.de/#faq): Erstattung, Ablauf und Termindauer
+- [Terminanfrage](https://saim-mobilephysio.de/#anmeldung): Kontaktformular für Terminwünsche
+- [Kontakt](https://saim-mobilephysio.de/#kontakt): Telefon, E-Mail und Adresse
+- [Datenschutzerklärung](https://saim-mobilephysio.de/privacy)
+- [Impressum](https://saim-mobilephysio.de/terms)


### PR DESCRIPTION
## Summary

Fixes the two failing **Agentic Browsing** audits from the [PageSpeed Insights report](https://pagespeed.web.dev/analysis/https-saim-mobilephysio-de/pe8t6cwa2x?form_factor=desktop) (category was 1/3):

- **Accessibility tree is not well-formed**: the services grid used `<article role="listitem">` inside `<div role="list">`; `article` may not carry the `listitem` role. Replaced with native `<ul>`/`<li>` (keeping `role="list"` on the `ul` so Safari retains list semantics despite `list-style: none`).
- **llms.txt fetch failed**: added `public/llms.txt` (Markdown with H1, summary blockquote, key links). All facts sourced from `lib/seo.js`, the FAQ items, and `Contact.js` — no invented content.

## Verification

- `bun run build` passes; served build inspected in browser — services grid renders pixel-identical (`.card` sets `display:flex`, globals reset `ul`; print rules already cover `li`).
- Local Lighthouse `agentic-browsing` category on the built site: **1.0** — `agent-accessibility-tree` and `llms-txt` both pass, CLS still 0.
- `/llms.txt` serves correctly from the production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167pvPhnm1sM4u8bNz322XL