### PR TITLE
fix(content): correct llms.txt facts and add missing faq anchor

### DIFF
--- a/components/Faq.js
+++ b/components/Faq.js
@@ -25,7 +25,7 @@ const FAQ = [
 
 export default function Faq() {
   return (
-    <section className={styles.section} aria-labelledby="faq-title">
+    <section className={styles.section} id="faq" aria-labelledby="faq-title">
       <header className={styles.head}>
         <div>
           <div className={styles.numTag}>FAQ</div>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -2,19 +2,19 @@
 
 > Mobile Physiotherapie in Sankt Augustin, Bonn und Umgebung: Hausbesuche, Manuelltherapie, Lymphdrainage und Personal Training mit Faranak Nokhbehzaeem.
 
-Saim Mobilephysio ist eine mobile Physiotherapie-Praxis. Alle Behandlungen finden als Hausbesuche statt — Liege, Materialien und Tapes werden mitgebracht. Eine Sitzung dauert verlässlich 60 Minuten. Behandlungen sind mit ärztlichem Rezept oder ohne Verordnung (präventiv, Personal Training, Wellness) möglich; abgerechnet wird nach den Sätzen des Honorarkatalogs.
+Saim Mobilephysio ist eine mobile Physiotherapie-Praxis. Alle Behandlungen finden als Hausbesuche statt — Liege, Materialien und Tapes werden mitgebracht. Eine reguläre Sitzung dauert 60 Minuten; 30-minütige Behandlungen werden als volle Stunde abgerechnet. Behandlungen sind mit ärztlichem Rezept oder ohne Verordnung (präventiv, Personal Training, Wellness) möglich; abgerechnet wird nach den Sätzen des Honorarkatalogs.
 
-- Inhaberin und Therapeutin: Faranak Nokhbehzaeem, staatlich anerkannte Physiotherapeutin, Manuelltherapeutin, Ödemtherapeutin und Personal Trainerin
+- Gründerin und Therapeutin: Faranak Nokhbehzaeem, staatlich anerkannte Physiotherapeutin, Manuelltherapeutin, Ödemtherapeutin und Personal Trainerin
 - Adresse: Wacholderweg 6, 53757 Sankt Augustin, Nordrhein-Westfalen, Deutschland
 - Telefon: +49 157 85 90 8915
 - E-Mail: info@saim-mobilephysio.de
 - Sprachen: Deutsch, Persisch (Farsi)
-- Einzugsgebiet: Radius von 20 km um Sankt Augustin — u. a. Bonn, Siegburg, Troisdorf, Hennef, Königswinter, Bad Honnef, Niederkassel, Lohmar, Much
-- Preisspanne: 15 EUR bis 150 EUR, Hausbesuch 28 EUR
+- Einzugsgebiet: rund 20 km um Sankt Augustin — Hausbesuche u. a. in Bonn, Siegburg, Troisdorf, Hennef, Königswinter, Bad Honnef, Niederkassel, Lohmar und Much; weiter entfernte Wohnorte auf Anfrage
+- Preisspanne: 15 EUR bis 150 EUR; Hausbesuch 28 EUR zzgl. 0,50 EUR/km
 
 ## Leistungen
 
-Zwölf Behandlungsformen: Manuelle Therapie, Physiotherapie (Krankengymnastik), Manuelle Lymphdrainage, Atemtherapie, Migränetherapie, Akupressur, Beckenboden- und Rückentraining, Koordinations-, Ausdauer- und Krafttraining (Personal Training), Wellnessbehandlungen, Kinesiologische Tapetechniken, Massage sowie Ozon-/Plasma-Therapie.
+Zwölf Behandlungsformen: Manuelle Therapie, Physiotherapie (Krankengymnastik), Manuelle Lymphdrainage, Atemtherapie, Migränetherapie, Akupressur, Beckenboden- und Rückentraining, Koordination, Ausdauer und Krafttraining (Personal Training), Wellnessbehandlungen, Kinesiologische Tapetechniken, Massage sowie Ozon-/Plasma-Therapie.
 
 ## Wichtige Seiten
 
@@ -24,6 +24,6 @@ Zwölf Behandlungsformen: Manuelle Therapie, Physiotherapie (Krankengymnastik), 
 - [Einzugsgebiet](https://saim-mobilephysio.de/#einzugsgebiet): Orte und Radius der Hausbesuche
 - [Häufige Fragen](https://saim-mobilephysio.de/#faq): Erstattung, Ablauf und Termindauer
 - [Terminanfrage](https://saim-mobilephysio.de/#anmeldung): Kontaktformular für Terminwünsche
-- [Kontakt](https://saim-mobilephysio.de/#kontakt): Telefon, E-Mail und Adresse
+- [Kontakt](https://saim-mobilephysio.de/#kontakt): Telefon, E-Mail und Einzugsgebiet
 - [Datenschutzerklärung](https://saim-mobilephysio.de/privacy)
 - [Impressum](https://saim-mobilephysio.de/terms)


### PR DESCRIPTION
## Summary

Follow-up to #84, addressing all seven findings from the adversarial (Codex) review of the llms.txt content:

- **Add `id="faq"` to the FAQ section** — pre-existing bug: the FAQPage structured data (`lib/seo.js`) and llms.txt both link `/#faq`, but only `id="faq-title"` existed in the DOM.
- **llms.txt factual corrections**, each now verbatim-traceable to repo sources:
  - "Gründerin und Therapeutin" instead of "Inhaberin" (matches `founder` in structured data)
  - verbatim service name "Koordination, Ausdauer und Krafttraining" (`lib/seo.js:76`)
  - session length now notes 30-minute treatments are billed as a full hour (services footnote)
  - service radius softened to "rund 20 km …; weiter entfernte Wohnorte auf Anfrage" (Area.js lists Much at 22 km; FAQ offers on-request)
  - house-visit fee now includes "zzgl. 0,50 EUR/km" (`Pricing.js`)
  - Kontakt link description corrected — that section shows Telefon/E-Mail/Einzugsgebiet, not a postal address

`bun run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167pvPhnm1sM4u8bNz322XL